### PR TITLE
Added state and reached marker telemetry

### DIFF
--- a/autonomy.py
+++ b/autonomy.py
@@ -27,6 +27,17 @@ async def autonomy_state_loop():
 
         logger.debug(f"Current State: {core.states.state_machine.state}")
 
+        # Transmit the current state to Base Station
+        core.rovecomm_node.write(
+            core.RoveCommPacket(
+                core.manifest["Autonomy"]["Telemetry"]["CurrentState"]["dataId"],
+                "B",
+                (core.states.StateMapping[core.states.state_machine.state],),
+                port=core.UDP_OUTGOING_PORT,
+            ),
+            False,
+        )
+
         # Core state machine runs every X ms, to prevent unecessarily fast computation.
         # Sensor data is processed seperately, as that is the bulk of processing time
         await asyncio.sleep(core.EVENT_LOOP_DELAY)

--- a/core/manifest.json
+++ b/core/manifest.json
@@ -238,31 +238,44 @@
         "Ip": "192.168.1.139",
         "Port": 11015,
         "Commands": {
-            "EnableAutonomy": {
-                "dataId": 11100,
-                "dataType": "DataTypes.UINT8_T",
-                "dataCount": 1,
-                "comments": "Starts Autonomy navigation"
-            },
-            "DisableAutonomy": {
-                "dataId": 11101,
-                "dataType": "DataTypes.UINT8_T",
-                "dataCount": 1,
-                "comments": "Stops Autonomy navigation"
-            },
-            "AddWaypoint": {
-                "dataId": 11102,
-                "dataType": "DataTypes.DOUBLE",
-                "dataCount": 2,
-                "comments": "Adds a new waypoint to Autonomy"
-            },
-            "ClearWaypoints": {
-                "dataId": 11103,
-                "dataType": "DataTypes.UINT8_T",
-                "dataCount": 2,
-                "comments": "Clears all the waypoints loaded in autonomy"
-            }
+        "EnableAutonomy": {
+            "dataId": 11000,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "Starts Autonomy navigation"
         },
-        "Telemetry": {}
+        "DisableAutonomy": {
+            "dataId": 11001,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "Stops Autonomy navigation"
+        },
+        "AddWaypoint": {
+            "dataId": 11002,
+            "dataType": "DataTypes.DOUBLE",
+            "dataCount": 2,
+            "comments": "Adds a new waypoint to Autonomy"
+        },
+        "ClearWaypoints": {
+            "dataId": 11003,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "Clears all the waypoints loaded in autonomy"
+        }
+        },
+        "Telemetry": {
+        "CurrentState": {
+            "dataId": 11100,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "The current state of the state machine"
+        },
+        "ReachedMarker": {
+            "dataId": 11101,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "Indicates that we have reached the marker"
+        }
+        }
     }
 }

--- a/core/manifest_sim.json
+++ b/core/manifest_sim.json
@@ -263,6 +263,19 @@
             "comments": "Clears all the waypoints loaded in autonomy"
         }
         },
-        "Telemetry": {}
+        "Telemetry": {
+        "CurrentState": {
+            "dataId": 11100,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "The current state of the state machine"
+        },
+        "ReachedMarker": {
+            "dataId": 11101,
+            "dataType": "DataTypes.UINT8_T",
+            "dataCount": 1,
+            "comments": "Indicates that we have reached the marker"
+        }
+        }
     }
 }

--- a/core/rovecomm.py
+++ b/core/rovecomm.py
@@ -277,7 +277,8 @@ class RoveCommEthernetUdp:
             if packet.ip_address != ("0.0.0.0", 0):
                 self.RoveCommSocket.sendto(rovecomm_packet, packet.ip_address)
             return 1
-        except Exception:
+        except Exception as e:
+            print(e)
             return 0
 
     def read(self):

--- a/core/rovecomm.py
+++ b/core/rovecomm.py
@@ -277,8 +277,7 @@ class RoveCommEthernetUdp:
             if packet.ip_address != ("0.0.0.0", 0):
                 self.RoveCommSocket.sendto(rovecomm_packet, packet.ip_address)
             return 1
-        except Exception as e:
-            print(e)
+        except Exception:
             return 0
 
     def read(self):

--- a/core/rovecomm.py
+++ b/core/rovecomm.py
@@ -87,7 +87,7 @@ class RoveCommPacket:
         elif ip_octet_4 != "" and len(ip_octet_4) >= 4:
             self.ip_address = (ip_octet_4, port)
         else:
-            self.ip_address = ("0.0.0.0", port)
+            self.ip_address = ("0.0.0.0", 0)
         return
 
     def SetIp(self, ip, port=None):
@@ -439,6 +439,7 @@ class RoveCommEthernetTcp:
         # from blocking the thread while waiting for a request
         if len(select.select([self.server], [], [], 0)[0]) > 0:
             conn, addr = self.server.accept()
+            print(conn)
             self.open_sockets[addr[0]] = conn
             self.incoming_sockets[addr[0]] = conn
 

--- a/core/states/__init__.py
+++ b/core/states/__init__.py
@@ -24,3 +24,11 @@ class AutonomyEvents(Enum):
     END_OBSTACLE_AVOIDANCE = 11
     NO_WAYPOINT = 12
     NEW_WAYPOINT = 13
+
+
+StateMapping = {
+    Idle(): 0,
+    Navigating(): 1,
+    SearchPattern(): 2,
+    ApproachingMarker(): 3,
+}

--- a/core/states/approaching_marker.py
+++ b/core/states/approaching_marker.py
@@ -66,6 +66,16 @@ class ApproachingMarker(RoverState):
 
                 self.logger.info("Reached Marker")
 
+                # Transmit that we have reached the marker
+                core.rovecomm_node.write(
+                    core.RoveCommPacket(
+                        core.manifest["Autonomy"]["Telemetry"]["ReachedMarker"]["dataId"],
+                        "B",
+                        (1),
+                    ),
+                    True,
+                )
+
                 # TODO: Add support for notifying (with LEDs) that we have reached marker
                 # core.notify.notify_finish()
                 return self.on_event(core.AutonomyEvents.REACHED_MARKER)

--- a/run.py
+++ b/run.py
@@ -67,7 +67,7 @@ def main() -> None:
     logger = setup_logger(level)
 
     # Initialize the rovecomm node
-    core.rovecomm_node = core.RoveComm(11000, ("127.0.0.1", 11117))
+    core.rovecomm_node = core.RoveComm(11000, ("127.0.0.1", 11111))
 
     # Initialize the core handlers (excluding vision)
     core.setup(args.mode)

--- a/run.py
+++ b/run.py
@@ -67,7 +67,7 @@ def main() -> None:
     logger = setup_logger(level)
 
     # Initialize the rovecomm node
-    core.rovecomm_node = core.RoveComm(11000, ("127.0.0.1", 11111))
+    core.rovecomm_node = core.RoveComm(11000, ("127.0.0.1", 11117))
 
     # Initialize the core handlers (excluding vision)
     core.setup(args.mode)

--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -25,8 +25,7 @@ this string should go over it"""
     core.rovecomm_node.set_callback(4243, handle_packet)
 
     # Subscribe to our own packets
-    packet = RoveCommPacket(ROVECOMM_SUBSCRIBE_REQUEST, "b", (), "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(ROVECOMM_SUBSCRIBE_REQUEST, "b", (), "127.0.0.1", 11000)
     core.rovecomm_node.write(packet, False)
 
     core.rovecomm_node.tcp_node.connect(("127.0.0.1", 11111))

--- a/tests/unit/rovecomm_test.py
+++ b/tests/unit/rovecomm_test.py
@@ -203,7 +203,7 @@ def test_udp_unsubscribe():
 
     # Main target should be invalid
     core.rovecomm_node.set_callback(4233, handle_packet)
-    packet2 = RoveCommPacket(4233, "b", (), "127.0.0.1", 0)
+    packet2 = RoveCommPacket(4233, "b", (), "", 0)
     assert core.rovecomm_node.write(packet2, False) == 1
 
     # Packet should not still be recieved because we unsubscribed

--- a/tests/unit/rovecomm_test.py
+++ b/tests/unit/rovecomm_test.py
@@ -17,8 +17,7 @@ def test_udp():
     global responses
     core.rovecomm_node.set_callback(4242, handle_packet)
 
-    packet = RoveCommPacket(4242, "b", (1, 3), "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4242, "b", (1, 3), "127.0.0.1", 11000)
     assert core.rovecomm_node.write(packet, False) == 1
 
     # Give the listener thread a moment to catch the packet
@@ -37,8 +36,7 @@ def test_tcp():
     # a dictionary of connection sockets, allowing it to create
     # a TCP connection between its server and one of the dictionary
     # sockets
-    packet = RoveCommPacket(4241, "b", (1, 4), "", 11111)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4241, "b", (1, 4), "127.0.0.1", 11111)
     assert core.rovecomm_node.write(packet, True) == 1
 
     # Give the listener thread a moment to catch the packet
@@ -57,7 +55,7 @@ def test_tcp_subscribers():
     # a dictionary of connection sockets, allowing it to create
     # a TCP connection between its server and one of the dictionary
     # sockets
-    packet = RoveCommPacket(4243, "b", (1, 4), "", 0)
+    packet = RoveCommPacket(4243, "b", (1, 4), "127.0.0.1", 11111)
 
     core.rovecomm_node.tcp_node.connect(("127.0.0.1", 11111))
 
@@ -77,7 +75,7 @@ def test_udp_external():
 
     # Test socket to try to send to RoveComm over UDP
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(("", 11001))
+    s.bind(("127.0.0.1", 11001))
 
     rovecomm_packet = struct.pack(">BHBB", 2, 4240, 2, 0)
     data = (1, 6)
@@ -92,6 +90,7 @@ def test_udp_external():
     assert responses[4240].data_type == "b"
     assert responses[4240].data_count == len(data)
     assert responses[4240].data_id == 4240
+    s.close()
 
 
 def test_tcp_external():
@@ -118,8 +117,7 @@ def test_tcp_external():
 
 def test_invalid_target():
     # Sends to a port that won't be available
-    packet = RoveCommPacket(4238, "b", (0,), "", 99999)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4238, "b", (0,), "127.0.0.1", 99999)
     assert core.rovecomm_node.write(packet, True) == 0
     assert core.rovecomm_node.write(packet, False) == 0
 
@@ -128,16 +126,14 @@ def test_callback_exception():
     global response
     core.rovecomm_node.set_callback(4237, handle_packet_exception)
 
-    packet = RoveCommPacket(4237, "b", (1, 3), "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4237, "b", (1, 3), "127.0.0.1", 11000)
     assert core.rovecomm_node.write(packet, False) == 1
 
     # RoveComm passes on callback exception, nothing else to do
 
 
 def test_print_packet():
-    packet = RoveCommPacket(4236, "b", (1, 4), "", 11111)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4236, "b", (1, 4), "127.0.0.1", 11111)
     # Temporarily changes stdout to write into an easily accessible output
     with captured_output() as (out, err):
         packet.print()
@@ -157,15 +153,13 @@ Data:  (1, 4)
 
 def test_invalid_write_udp():
     # Sends non-tuple data
-    packet = RoveCommPacket(4235, "b", "a", "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4235, "b", "a", "127.0.0.1", 11000)
     assert core.rovecomm_node.write(packet, False) == 0
 
 
 def test_invalid_write_tcp():
     # Sends non-tuple data
-    packet = RoveCommPacket(4235, "b", "a", "", 11111)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4235, "b", "a", "127.0.0.1", 11111)
     assert core.rovecomm_node.write(packet, True) == 0
 
 
@@ -176,8 +170,7 @@ def test_udp_subscribe():
     global responses
     core.rovecomm_node.set_callback(3, handle_packet)
 
-    packet = RoveCommPacket(3, "b", (), "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(3, "b", (), "127.0.0.1", 11000)
     assert core.rovecomm_node.write(packet, False) == 1
 
     time.sleep(0.05)
@@ -187,7 +180,6 @@ def test_udp_subscribe():
     # Main target should be invalid
     core.rovecomm_node.set_callback(4234, handle_packet)
     packet2 = RoveCommPacket(4234, "b", (), "", 0)
-    packet2.SetIp("0.0.0.0")
     assert core.rovecomm_node.write(packet2, False) == 1
 
     # Packet should still be recieved because we're subscribed
@@ -202,8 +194,7 @@ def test_udp_unsubscribe():
     global responses
     core.rovecomm_node.set_callback(4, handle_packet)
 
-    packet = RoveCommPacket(4, "b", (), "", 11000)
-    packet.SetIp("127.0.0.1")
+    packet = RoveCommPacket(4, "b", (), "127.0.0.1", 11000)
     assert core.rovecomm_node.write(packet, False) == 1
 
     time.sleep(0.05)
@@ -212,8 +203,7 @@ def test_udp_unsubscribe():
 
     # Main target should be invalid
     core.rovecomm_node.set_callback(4233, handle_packet)
-    packet2 = RoveCommPacket(4233, "b", (), "", 0)
-    packet2.SetIp("0.0.0.0")
+    packet2 = RoveCommPacket(4233, "b", (), "127.0.0.1", 0)
     assert core.rovecomm_node.write(packet2, False) == 1
 
     # Packet should not still be recieved because we unsubscribed
@@ -252,7 +242,7 @@ def test_invalid_rovecomm_version_udp():
 
     # Test socket to try to send to RoveComm over UDP
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(("", 11001))
+    s.bind(("127.0.0.1", 11001))
 
     rovecomm_packet = struct.pack(">BHBB", 1, 4231, 2, 0)
     data = (1, 6)
@@ -267,6 +257,7 @@ def test_invalid_rovecomm_version_udp():
     assert responses[5].data_type == "b"
     assert responses[5].data_count == 1
     assert responses[5].data_id == 5
+    s.close()
 
 
 def test_read_exception_udp():
@@ -283,7 +274,7 @@ def test_read_exception_udp():
 
     # Send a packet so recv can be triggered
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.bind(("", 11001))
+    s.bind(("127.0.0.1", 11001))
 
     rovecomm_packet = struct.pack(">BHBB", 1, 4230, 2, 0)
     data = (1, 6)
@@ -302,6 +293,7 @@ def test_read_exception_udp():
 
     # Gives the udp node its socket back
     core.rovecomm_node.udp_node.RoveCommSocket = temp
+    s.close()
 
 
 def test_listener_shutdown():


### PR DESCRIPTION
Sending the current state as telemetry every autonomy event loop (currently like ~0.07 seconds, but could be potentially slower if telemetry spam becomes a concern).


Also changes TCP behaviour to now default port and address to 0 if "" is passed in as an IP.